### PR TITLE
chore(memory-routes): explicit null check + disabled-backend regression test

### DIFF
--- a/src/services/worker/http/routes/MemoryRoutes.ts
+++ b/src/services/worker/http/routes/MemoryRoutes.ts
@@ -69,17 +69,19 @@ export class MemoryRoutes extends BaseRouteHandler {
     });
 
     // 4. Sync to the active vector backend (async, fire-and-forget)
-    vectorSync?.syncObservation(
-      result.id,
-      memorySessionId,
-      targetProject,
-      observation,
-      0,
-      result.createdAtEpoch,
-      0
-    ).catch(err => {
-      logger.error('VECTOR_BACKEND', 'Vector sync failed for manual observation', { id: result.id }, err as Error);
-    });
+    if (vectorSync) {
+      vectorSync.syncObservation(
+        result.id,
+        memorySessionId,
+        targetProject,
+        observation,
+        0,
+        result.createdAtEpoch,
+        0
+      ).catch(err => {
+        logger.error('VECTOR_BACKEND', 'Vector sync failed for manual observation', { id: result.id }, err as Error);
+      });
+    }
 
     // 5. Return success
     res.json({

--- a/tests/worker/memory-routes-disabled-vector-sync.test.ts
+++ b/tests/worker/memory-routes-disabled-vector-sync.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import express from 'express';
+import { mkdirSync, rmSync } from 'fs';
+import { randomUUID } from 'crypto';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { logger } from '../../src/utils/logger.js';
+
+import { DatabaseManager } from '../../src/services/worker/DatabaseManager.js';
+import { MemoryRoutes } from '../../src/services/worker/http/routes/MemoryRoutes.js';
+import { SettingsDefaultsManager } from '../../src/shared/SettingsDefaultsManager.js';
+
+describe('MemoryRoutes disabled vector sync', () => {
+  let tempRoot: string;
+  let loggerSpies: ReturnType<typeof spyOn>[] = [];
+
+  beforeEach(() => {
+    tempRoot = join(tmpdir(), `claude-mem-memory-routes-${randomUUID()}`);
+    mkdirSync(tempRoot, { recursive: true });
+
+    loggerSpies = [
+      spyOn(logger, 'info').mockImplementation(() => {}),
+      spyOn(logger, 'debug').mockImplementation(() => {}),
+      spyOn(logger, 'warn').mockImplementation(() => {}),
+      spyOn(logger, 'error').mockImplementation(() => {}),
+      spyOn(logger, 'failure').mockImplementation(() => {}),
+    ];
+
+    spyOn(SettingsDefaultsManager, 'loadFromFile').mockReturnValue({
+      CLAUDE_MEM_VECTOR_BACKEND: '',
+      CLAUDE_MEM_CHROMA_ENABLED: 'false',
+    } as any);
+  });
+
+  afterEach(() => {
+    loggerSpies.forEach((spy) => spy.mockRestore());
+    mock.restore();
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('stores a manual observation when vector sync is disabled', async () => {
+    const dbPath = join(tempRoot, 'claude-mem.db');
+    const dbManager = new DatabaseManager(dbPath);
+    await dbManager.initialize();
+
+    expect(dbManager.getVectorSync()).toBeNull();
+
+    const routes = new MemoryRoutes(dbManager, 'test-project');
+    const app = express();
+    app.use(express.json());
+    routes.setupRoutes(app);
+
+    const server = app.listen(0, '127.0.0.1');
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.once('listening', resolve);
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Test server failed to start');
+      }
+
+      const response = await fetch(`http://127.0.0.1:${address.port}/api/memory/save`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          text: 'Manual memory capture for a disabled vector backend.',
+          title: 'Disabled backend memory',
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      expect(body).toEqual(expect.objectContaining({
+        success: true,
+        title: 'Disabled backend memory',
+        project: 'test-project',
+      }));
+
+      const store = dbManager.getSessionStore();
+      const observation = store.db.prepare(`
+        SELECT id, memory_session_id, project, title, narrative
+        FROM observations
+        WHERE id = ?
+      `).get(body.id) as {
+        id: number;
+        memory_session_id: string;
+        project: string;
+        title: string;
+        narrative: string;
+      } | undefined;
+
+      expect(observation).toEqual(expect.objectContaining({
+        memory_session_id: 'manual-test-project',
+        project: 'test-project',
+        title: 'Disabled backend memory',
+        narrative: 'Manual memory capture for a disabled vector backend.',
+      }));
+
+      const session = store.db.prepare(`
+        SELECT memory_session_id, project
+        FROM sdk_sessions
+        WHERE memory_session_id = ?
+      `).get('manual-test-project') as {
+        memory_session_id: string;
+        project: string;
+      } | undefined;
+
+      expect(session).toEqual({
+        memory_session_id: 'manual-test-project',
+        project: 'test-project',
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+      await dbManager.close();
+    }
+  });
+});


### PR DESCRIPTION
## Context

PR #34 review flagged `vectorSync?.syncObservation(...).catch(...)` as a P1 crash candidate when `vectorSync` is null. After empirical verification, this turned out to be a false alarm — JavaScript's optional chaining short-circuits the **entire** chain, so when `vectorSync` is null the whole expression evaluates to `undefined` and `.catch(...)` is never invoked.

Verified with:
```ts
const x: { foo: () => Promise<void> } | null = null;
const r = x?.foo().catch(err => {}); // r === undefined, no throw
```

## What this PR actually does

- **Defensive code clarity**: replaces optional chaining + ignored result with an explicit `if (vectorSync) { ... }` block. Behaviour is identical, intent is more obvious to future readers.
- **Regression test**: adds `tests/worker/memory-routes-disabled-vector-sync.test.ts` (125 lines) that exercises the disabled-backend path (`CLAUDE_MEM_VECTOR_BACKEND=` + `CLAUDE_MEM_CHROMA_ENABLED=false`) end-to-end through `POST /api/memory/save` and asserts SQLite persistence still works without throwing. This guards against future refactors that might remove the optional chaining without re-adding a null check.

## Test plan

- [x] `bun test --preload ./tests/test-setup.ts tests/worker/memory-routes-disabled-vector-sync.test.ts` — 1 pass / 0 fail / 5 expect calls
- [x] `npx lefthook run pre-commit` — bun test + tsc --noEmit
- [x] Working tree clean; no other side effects

## Why merge anyway (no real bug fix)

The optional chaining was already correct, but: (a) explicit `if` is more obvious; (b) the regression test is a useful guard regardless of which form the code uses. PR #34 review's P1 finding can be considered closed by this defensive coverage.