### PR TITLE
feat(prompt-sync): defer initial prompt vector sync until memory_session_id is captured

### DIFF
--- a/src/services/worker/SDKAgent.ts
+++ b/src/services/worker/SDKAgent.ts
@@ -187,6 +187,9 @@ export class SDKAgent {
             memorySessionId: message.session_id,
             previousId
           });
+          if (!previousId) {
+            await this.syncLatestPromptAfterMemoryCapture(session.contentSessionId, message.session_id);
+          }
           if (!dbVerified) {
             logger.error('SESSION', `MEMORY_ID_MISMATCH | sessionDbId=${session.sessionDbId} | expected=${message.session_id} | got=${verification?.memory_session_id}`, {
               sessionId: session.sessionDbId
@@ -450,6 +453,40 @@ export class SDKAgent {
           isSynthetic: true
         };
       }
+    }
+  }
+
+  private async syncLatestPromptAfterMemoryCapture(
+    contentSessionId: string,
+    memorySessionId: string
+  ): Promise<void> {
+    const latestPrompt = this.dbManager.getSessionStore().getLatestUserPrompt(contentSessionId);
+    const vectorSync = this.dbManager.getVectorSync();
+
+    if (!latestPrompt || !vectorSync) {
+      return;
+    }
+
+    try {
+      await vectorSync.syncUserPrompt(
+        latestPrompt.id,
+        memorySessionId,
+        latestPrompt.project,
+        latestPrompt.prompt_text,
+        latestPrompt.prompt_number,
+        latestPrompt.created_at_epoch
+      );
+      logger.debug('CHROMA', 'Backfilled initial user prompt after memory id capture', {
+        promptId: latestPrompt.id,
+        contentSessionId,
+        promptNumber: latestPrompt.prompt_number
+      });
+    } catch (error) {
+      logger.error('CHROMA', 'Failed to backfill initial user prompt after memory id capture', {
+        promptId: latestPrompt.id,
+        contentSessionId,
+        promptNumber: latestPrompt.prompt_number
+      }, error as Error);
     }
   }
 

--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -335,32 +335,41 @@ export class SessionRoutes extends BaseRouteHandler {
         created_at_epoch: latestPrompt.created_at_epoch
       });
 
-      // Sync user prompt to the selected vector backend
-      const vectorSyncStart = Date.now();
       const promptText = latestPrompt.prompt_text;
-      this.dbManager.getVectorSync()?.syncUserPrompt(
-        latestPrompt.id,
-        latestPrompt.memory_session_id,
-        latestPrompt.project,
-        promptText,
-        latestPrompt.prompt_number,
-        latestPrompt.created_at_epoch
-      ).then(() => {
-        const vectorSyncDuration = Date.now() - vectorSyncStart;
-        const truncatedPrompt = promptText.length > 60
-          ? promptText.substring(0, 60) + '...'
-          : promptText;
-        logger.debug('CHROMA', 'User prompt synced', {
+
+      if (!latestPrompt.memory_session_id) {
+        logger.debug('CHROMA', 'Skipping prompt sync until memory session id is available', {
           promptId: latestPrompt.id,
-          duration: `${vectorSyncDuration}ms`,
-          prompt: truncatedPrompt
+          contentSessionId: latestPrompt.content_session_id,
+          promptNumber: latestPrompt.prompt_number
         });
-      }).catch((error) => {
-        logger.error('CHROMA', 'User prompt vector sync failed, continuing without vector search', {
-          promptId: latestPrompt.id,
-          prompt: promptText.length > 60 ? promptText.substring(0, 60) + '...' : promptText
-        }, error);
-      });
+      } else {
+        // Sync user prompt to the selected vector backend
+        const vectorSyncStart = Date.now();
+        this.dbManager.getVectorSync()?.syncUserPrompt(
+          latestPrompt.id,
+          latestPrompt.memory_session_id,
+          latestPrompt.project,
+          promptText,
+          latestPrompt.prompt_number,
+          latestPrompt.created_at_epoch
+        ).then(() => {
+          const vectorSyncDuration = Date.now() - vectorSyncStart;
+          const truncatedPrompt = promptText.length > 60
+            ? promptText.substring(0, 60) + '...'
+            : promptText;
+          logger.debug('CHROMA', 'User prompt synced', {
+            promptId: latestPrompt.id,
+            duration: `${vectorSyncDuration}ms`,
+            prompt: truncatedPrompt
+          });
+        }).catch((error) => {
+          logger.error('CHROMA', 'User prompt vector sync failed, continuing without vector search', {
+            promptId: latestPrompt.id,
+            prompt: promptText.length > 60 ? promptText.substring(0, 60) + '...' : promptText
+          }, error);
+        });
+      }
     }
 
     // Idempotent: ensure generator is running (matches handleObservations / handleSummarize)

--- a/tests/sdk-agent-first-prompt-sync.test.ts
+++ b/tests/sdk-agent-first-prompt-sync.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { SDKAgent } from '../src/services/worker/SDKAgent.js';
+
+describe('SDKAgent first prompt sync backfill', () => {
+  it('backfills the latest prompt after capturing the first memory session id', async () => {
+    const syncUserPrompt = mock(async () => {});
+    const dbManager = {
+      getSessionStore: () => ({
+        getLatestUserPrompt: () => ({
+          id: 17,
+          content_session_id: 'content-session-1',
+          memory_session_id: null,
+          project: 'test-project',
+          prompt_number: 1,
+          prompt_text: 'Investigate vector backend routing',
+          created_at: new Date(1700000000000).toISOString(),
+          created_at_epoch: 1700000000,
+        })
+      }),
+      getVectorSync: () => ({
+        syncUserPrompt
+      })
+    } as any;
+
+    const agent = new SDKAgent(dbManager, {} as any);
+
+    await (agent as any).syncLatestPromptAfterMemoryCapture('content-session-1', 'memory-session-1');
+
+    expect(syncUserPrompt).toHaveBeenCalledWith(
+      17,
+      'memory-session-1',
+      'test-project',
+      'Investigate vector backend routing',
+      1,
+      1700000000
+    );
+  });
+
+  it('does nothing when there is no prompt or vector backend to backfill', async () => {
+    const syncUserPrompt = mock(async () => {});
+    const agentWithoutPrompt = new SDKAgent({
+      getSessionStore: () => ({
+        getLatestUserPrompt: () => undefined
+      }),
+      getVectorSync: () => ({
+        syncUserPrompt
+      })
+    } as any, {} as any);
+
+    await (agentWithoutPrompt as any).syncLatestPromptAfterMemoryCapture('content-session-1', 'memory-session-1');
+
+    const agentWithoutBackend = new SDKAgent({
+      getSessionStore: () => ({
+        getLatestUserPrompt: () => ({
+          id: 17,
+          content_session_id: 'content-session-1',
+          memory_session_id: null,
+          project: 'test-project',
+          prompt_number: 1,
+          prompt_text: 'Investigate vector backend routing',
+          created_at: new Date(1700000000000).toISOString(),
+          created_at_epoch: 1700000000,
+        })
+      }),
+      getVectorSync: () => null
+    } as any, {} as any);
+
+    await (agentWithoutBackend as any).syncLatestPromptAfterMemoryCapture('content-session-1', 'memory-session-1');
+
+    expect(syncUserPrompt).not.toHaveBeenCalled();
+  });
+});

--- a/tests/worker/session-routes-vector-sync.test.ts
+++ b/tests/worker/session-routes-vector-sync.test.ts
@@ -126,4 +126,62 @@ describe('SessionRoutes vector sync routing', () => {
 
     await dbManager.close();
   });
+
+  it('skips prompt sync during init until memory session id exists', async () => {
+    const dbPath = join(tempRoot, 'claude-mem-no-memory-id.db');
+    const dbManager = new DatabaseManager(dbPath);
+    await dbManager.initialize();
+
+    const store = dbManager.getSessionStore();
+    const sessionDbId = store.createSDKSession(
+      'content-session-2',
+      'test-project',
+      'Investigate prompt routing',
+      undefined,
+      'claude'
+    );
+    store.saveUserPrompt('content-session-2', 1, 'Investigate prompt routing');
+
+    const sessionManager = new SessionManager(dbManager);
+    const vectorSync = dbManager.getVectorSync();
+    const syncUserPrompt = mock(() => Promise.resolve());
+    spyOn(vectorSync!, 'syncUserPrompt').mockImplementation(syncUserPrompt);
+
+    const routes = new SessionRoutes(
+      sessionManager,
+      dbManager,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        broadcastNewPrompt: mock(() => {}),
+        broadcastSessionStarted: mock(() => {}),
+      } as any,
+      {
+        notifyGlobalMessagePool: mock(() => {}),
+      } as any
+    );
+
+    const req = {
+      params: { sessionDbId: String(sessionDbId) },
+      body: { userPrompt: 'Investigate prompt routing', promptNumber: 1 },
+      path: `/sessions/${sessionDbId}/init`
+    } as any;
+    const res = {
+      headersSent: false,
+      status: mock(function status() { return res; }),
+      json: mock(() => res)
+    } as any;
+
+    await (routes as any).handleSessionInit(req, res);
+
+    expect(syncUserPrompt).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'initialized',
+      sessionDbId,
+      port: 37777
+    }));
+
+    await dbManager.close();
+  });
 });


### PR DESCRIPTION
## Context

The first user prompt of a session may be POSTed to the vector backend **before** the SDK agent has assigned a `memory_session_id` to the session. When that happens the prompt gets indexed without (or with a placeholder) session id, which breaks session-scoped vector queries.

## Two-phase fix

1. **Gate**: `SessionRoutes` prompt-sync path now checks `latestPrompt.memory_session_id`. If null, log debug and skip the sync (don't index a session-less prompt).
2. **Backfill**: `SDKAgent.handleMessageReceived` invokes a new method `syncLatestPromptAfterMemoryCapture` when `memory_session_id` is freshly captured (`!previousId`), backfilling whichever latest prompt was skipped earlier.

## Test plan

- [x] `bun test --preload ./tests/test-setup.ts tests/sdk-agent-first-prompt-sync.test.ts tests/worker/session-routes-vector-sync.test.ts` — 4 pass / 0 fail
- [x] Full `lefthook run pre-commit` — 1400 tests pass, typecheck clean
- [x] `npx tsc --noEmit` — clean

## Source

This work was sitting in a pre-existing stash from a prior session — fished out and verified during the post-PR #34/#35 cleanup. The unrelated `package.json` change (`prepare` → `hooks:install`, reverting lefthook auto-install) was intentionally **excluded** — that's a separate concern that should be a different PR if pursued.

## Reviewer focus

- **Idempotency**: backfill may call `syncUserPrompt` for a prompt that gets synced again later via the regular `SessionRoutes` path. Verify the vector backend dedupes by id (chroma upserts, sqlite-vec replaces). Double-indexing risk is low but worth confirming.
- **Error handling**: backfill is awaited but errors only logged — SDK agent flow doesn't block on vector backend latency or surface failures. Intentional but means silent backend issues won't appear in the SDK agent path.