### PR TITLE
fix(prompts): backfill un-synced user prompts post memory_session_id capture

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -62,6 +62,7 @@ export class SessionStore {
     this.addObservationHierarchicalFields();
     this.makeObservationsTextNullable();
     this.createUserPromptsTable();
+    this.addUserPromptVectorSyncedAtColumn();
     this.ensureDiscoveryTokensColumn();
     this.createPendingMessagesTable();
     this.addPendingMessagePriorityColumn();
@@ -440,6 +441,7 @@ export class SessionStore {
         content_session_id TEXT NOT NULL,
         prompt_number INTEGER NOT NULL,
         prompt_text TEXT NOT NULL,
+        vector_synced_at INTEGER,
         created_at TEXT NOT NULL,
         created_at_epoch INTEGER NOT NULL,
         FOREIGN KEY(content_session_id) REFERENCES sdk_sessions(content_session_id) ON DELETE CASCADE
@@ -492,6 +494,24 @@ export class SessionStore {
     this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(10, new Date().toISOString());
 
     logger.debug('DB', 'Successfully created user_prompts table');
+  }
+
+  /**
+   * Add vector_synced_at column to user_prompts for prompt-level backfill tracking (migration 29)
+   */
+  private addUserPromptVectorSyncedAtColumn(): void {
+    const tableInfo = this.db.query('PRAGMA table_info(user_prompts)').all() as TableColumnInfo[];
+    const hasColumn = tableInfo.some(col => col.name === 'vector_synced_at');
+    const applied = this.db.prepare('SELECT version FROM schema_versions WHERE version = ?').get(29) as SchemaVersion | undefined;
+
+    if (applied && hasColumn) return;
+
+    if (!hasColumn) {
+      this.db.run('ALTER TABLE user_prompts ADD COLUMN vector_synced_at INTEGER');
+      logger.debug('DB', 'Added vector_synced_at column to user_prompts table');
+    }
+
+    this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(29, new Date().toISOString());
   }
 
   /**
@@ -1297,11 +1317,12 @@ export class SessionStore {
   getLatestUserPrompt(contentSessionId: string): {
     id: number;
     content_session_id: string;
-    memory_session_id: string;
+    memory_session_id: string | null;
     project: string;
     platform_source: string;
     prompt_number: number;
     prompt_text: string;
+    vector_synced_at: number | null;
     created_at_epoch: number;
   } | undefined {
     const stmt = this.db.prepare(`
@@ -1318,6 +1339,28 @@ export class SessionStore {
     `);
 
     return stmt.get(contentSessionId) as LatestPromptResult | undefined;
+  }
+
+  /**
+   * Get all un-synced prompts for a content session in insertion order.
+   */
+  getUnsyncedUserPromptsByContentSessionId(contentSessionId: string): UserPromptRecord[] {
+    const stmt = this.db.prepare(`
+      SELECT
+        id,
+        content_session_id,
+        prompt_number,
+        prompt_text,
+        vector_synced_at,
+        created_at,
+        created_at_epoch
+      FROM user_prompts
+      WHERE content_session_id = ?
+        AND vector_synced_at IS NULL
+      ORDER BY id ASC
+    `);
+
+    return stmt.all(contentSessionId) as UserPromptRecord[];
   }
 
   /**
@@ -1745,12 +1788,23 @@ export class SessionStore {
 
     const stmt = this.db.prepare(`
       INSERT INTO user_prompts
-      (content_session_id, prompt_number, prompt_text, created_at, created_at_epoch)
-      VALUES (?, ?, ?, ?, ?)
+      (content_session_id, prompt_number, prompt_text, vector_synced_at, created_at, created_at_epoch)
+      VALUES (?, ?, ?, NULL, ?, ?)
     `);
 
     const result = stmt.run(contentSessionId, promptNumber, promptText, now.toISOString(), nowEpoch);
     return result.lastInsertRowid as number;
+  }
+
+  /**
+   * Mark a prompt as successfully synced to the vector backend.
+   */
+  markPromptVectorSynced(promptId: number, syncedAt: number): void {
+    this.db.prepare(`
+      UPDATE user_prompts
+      SET vector_synced_at = ?
+      WHERE id = ?
+    `).run(syncedAt, promptId);
   }
 
   /**

--- a/src/services/sqlite/migrations/029-add-user-prompts-vector-synced-at.sql
+++ b/src/services/sqlite/migrations/029-add-user-prompts-vector-synced-at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_prompts ADD COLUMN vector_synced_at INTEGER;

--- a/src/services/sqlite/migrations/runner.ts
+++ b/src/services/sqlite/migrations/runner.ts
@@ -31,6 +31,7 @@ export class MigrationRunner {
     this.addObservationHierarchicalFields();
     this.makeObservationsTextNullable();
     this.createUserPromptsTable();
+    this.addUserPromptVectorSyncedAtColumn();
     this.ensureDiscoveryTokensColumn();
     this.createPendingMessagesTable();
     this.renameSessionIdColumns();
@@ -411,6 +412,7 @@ export class MigrationRunner {
         content_session_id TEXT NOT NULL,
         prompt_number INTEGER NOT NULL,
         prompt_text TEXT NOT NULL,
+        vector_synced_at INTEGER,
         created_at TEXT NOT NULL,
         created_at_epoch INTEGER NOT NULL,
         FOREIGN KEY(content_session_id) REFERENCES sdk_sessions(content_session_id) ON DELETE CASCADE
@@ -463,6 +465,24 @@ export class MigrationRunner {
     this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(10, new Date().toISOString());
 
     logger.debug('DB', 'Successfully created user_prompts table');
+  }
+
+  /**
+   * Add vector_synced_at column to user_prompts for prompt-level backfill tracking (migration 29)
+   */
+  private addUserPromptVectorSyncedAtColumn(): void {
+    const tableInfo = this.db.query('PRAGMA table_info(user_prompts)').all() as TableColumnInfo[];
+    const hasColumn = tableInfo.some(col => col.name === 'vector_synced_at');
+    const applied = this.db.prepare('SELECT version FROM schema_versions WHERE version = ?').get(29) as SchemaVersion | undefined;
+
+    if (applied && hasColumn) return;
+
+    if (!hasColumn) {
+      this.db.run('ALTER TABLE user_prompts ADD COLUMN vector_synced_at INTEGER');
+      logger.debug('DB', 'Added vector_synced_at column to user_prompts table');
+    }
+
+    this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(29, new Date().toISOString());
   }
 
   /**

--- a/src/services/sqlite/prompts/get.ts
+++ b/src/services/sqlite/prompts/get.ts
@@ -5,7 +5,12 @@
 import type { Database } from 'bun:sqlite';
 import { logger } from '../../../utils/logger.js';
 import type { UserPromptRecord, LatestPromptResult } from '../../../types/database.js';
-import type { RecentUserPromptResult, PromptWithProject, GetPromptsByIdsOptions } from './types.js';
+import type {
+  RecentUserPromptResult,
+  PromptWithProject,
+  GetPromptsByIdsOptions,
+  UnsyncedPromptResult
+} from './types.js';
 
 /**
  * Get user prompt by session ID and prompt number
@@ -96,6 +101,7 @@ export function getPromptById(db: Database, id: number): PromptWithProject | nul
       p.content_session_id,
       p.prompt_number,
       p.prompt_text,
+      p.vector_synced_at,
       s.project,
       p.created_at,
       p.created_at_epoch
@@ -121,6 +127,7 @@ export function getPromptsByIds(db: Database, ids: number[]): PromptWithProject[
       p.content_session_id,
       p.prompt_number,
       p.prompt_text,
+      p.vector_synced_at,
       s.project,
       p.created_at,
       p.created_at_epoch
@@ -131,6 +138,31 @@ export function getPromptsByIds(db: Database, ids: number[]): PromptWithProject[
   `);
 
   return stmt.all(...ids) as PromptWithProject[];
+}
+
+/**
+ * Get un-synced user prompts for a session in stable insertion order.
+ */
+export function getUnsyncedUserPromptsByContentSessionId(
+  db: Database,
+  contentSessionId: string
+): UnsyncedPromptResult[] {
+  const stmt = db.prepare(`
+    SELECT
+      id,
+      content_session_id,
+      prompt_number,
+      prompt_text,
+      vector_synced_at,
+      created_at,
+      created_at_epoch
+    FROM user_prompts
+    WHERE content_session_id = ?
+      AND vector_synced_at IS NULL
+    ORDER BY id ASC
+  `);
+
+  return stmt.all(contentSessionId) as UnsyncedPromptResult[];
 }
 
 /**

--- a/src/services/sqlite/prompts/store.ts
+++ b/src/services/sqlite/prompts/store.ts
@@ -20,10 +20,25 @@ export function saveUserPrompt(
 
   const stmt = db.prepare(`
     INSERT INTO user_prompts
-    (content_session_id, prompt_number, prompt_text, created_at, created_at_epoch)
-    VALUES (?, ?, ?, ?, ?)
+    (content_session_id, prompt_number, prompt_text, vector_synced_at, created_at, created_at_epoch)
+    VALUES (?, ?, ?, NULL, ?, ?)
   `);
 
   const result = stmt.run(contentSessionId, promptNumber, promptText, now.toISOString(), nowEpoch);
   return result.lastInsertRowid as number;
+}
+
+/**
+ * Mark a user prompt as vector-synced.
+ */
+export function markPromptVectorSynced(
+  db: Database,
+  promptId: number,
+  syncedAt: number
+): void {
+  db.prepare(`
+    UPDATE user_prompts
+    SET vector_synced_at = ?
+    WHERE id = ?
+  `).run(syncedAt, promptId);
 }

--- a/src/services/sqlite/prompts/types.ts
+++ b/src/services/sqlite/prompts/types.ts
@@ -26,7 +26,18 @@ export interface PromptWithProject {
   content_session_id: string;
   prompt_number: number;
   prompt_text: string;
+  vector_synced_at: number | null;
   project: string;
+  created_at: string;
+  created_at_epoch: number;
+}
+
+export interface UnsyncedPromptResult {
+  id: number;
+  content_session_id: string;
+  prompt_number: number;
+  prompt_text: string;
+  vector_synced_at: number | null;
   created_at: string;
   created_at_epoch: number;
 }

--- a/src/services/worker/GeminiAgent.ts
+++ b/src/services/worker/GeminiAgent.ts
@@ -28,6 +28,7 @@ import {
   type WorkerRef,
   type FallbackAgent
 } from './agents/index.js';
+import { backfillUnsyncedPrompts } from './utils/promptBackfill.js';
 
 // Gemini API endpoint — use v1beta for preview models.
 // gemini-3-flash-preview is only available on v1beta, not v1.
@@ -144,6 +145,7 @@ export class GeminiAgent {
         this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, syntheticMemorySessionId);
         this.sessionManager.syncMemorySessionId(session.sessionDbId, syntheticMemorySessionId);
         logger.info('SESSION', `MEMORY_ID_GENERATED | sessionDbId=${session.sessionDbId} | provider=Gemini`);
+        await this.backfillPromptsAfterMemoryCapture(session, syntheticMemorySessionId);
       }
 
       // Load active mode
@@ -378,6 +380,20 @@ export class GeminiAgent {
       logger.failure('SDK', 'Gemini agent error', { sessionDbId: session.sessionDbId }, error as Error);
       throw error;
     }
+  }
+
+  private async backfillPromptsAfterMemoryCapture(
+    session: ActiveSession,
+    memorySessionId: string
+  ): Promise<void> {
+    await backfillUnsyncedPrompts(
+      this.dbManager.getSessionStore(),
+      session.contentSessionId,
+      memorySessionId,
+      session.project,
+      this.dbManager.getVectorSync(),
+      logger
+    );
   }
 
   /**

--- a/src/services/worker/OpenRouterAgent.ts
+++ b/src/services/worker/OpenRouterAgent.ts
@@ -29,6 +29,7 @@ import {
   type WorkerRef
 } from './agents/index.js';
 import { isGeminiAvailable } from './GeminiAgent.js';
+import { backfillUnsyncedPrompts } from './utils/promptBackfill.js';
 
 // Context window management constants (defaults, overridable via settings)
 const DEFAULT_MAX_CONTEXT_MESSAGES = 20;  // Maximum messages to keep in conversation history
@@ -176,6 +177,7 @@ export class OpenRouterAgent {
         this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, syntheticMemorySessionId);
         this.sessionManager.syncMemorySessionId(session.sessionDbId, syntheticMemorySessionId);
         logger.info('SESSION', `MEMORY_ID_GENERATED | sessionDbId=${session.sessionDbId} | provider=OpenRouter`);
+        await this.backfillPromptsAfterMemoryCapture(session, syntheticMemorySessionId);
       }
 
       // Load active mode
@@ -446,6 +448,20 @@ export class OpenRouterAgent {
       logger.failure('SDK', 'OpenRouter agent error (no fallback available)', { sessionDbId: session.sessionDbId }, error as Error);
       throw error;
     }
+  }
+
+  private async backfillPromptsAfterMemoryCapture(
+    session: ActiveSession,
+    memorySessionId: string
+  ): Promise<void> {
+    await backfillUnsyncedPrompts(
+      this.dbManager.getSessionStore(),
+      session.contentSessionId,
+      memorySessionId,
+      session.project,
+      this.dbManager.getVectorSync(),
+      logger
+    );
   }
 
   /**

--- a/src/services/worker/SDKAgent.ts
+++ b/src/services/worker/SDKAgent.ts
@@ -23,6 +23,7 @@ import { ModeManager } from '../domain/ModeManager.js';
 import { processAgentResponse, type WorkerRef } from './agents/index.js';
 import { createPidCapturingSpawn, getProcessBySession, ensureProcessExit, waitForSlot } from './ProcessRegistry.js';
 import { sanitizeEnv } from '../../supervisor/env-sanitizer.js';
+import { backfillUnsyncedPrompts } from './utils/promptBackfill.js';
 
 // Import Agent SDK (assumes it's installed)
 // @ts-ignore - Agent SDK types may not be available
@@ -168,30 +169,7 @@ export class SDKAgent {
         // This ensures FK constraint compliance BEFORE any observations are stored.
         if (message.session_id && message.session_id !== session.memorySessionId) {
           const previousId = session.memorySessionId;
-          session.memorySessionId = message.session_id;
-          this.sessionManager.syncMemorySessionId(session.sessionDbId, message.session_id);
-          // Persist to database IMMEDIATELY for FK constraint compliance
-          // This must happen BEFORE any observations referencing this ID are stored
-          this.dbManager.getSessionStore().ensureMemorySessionIdRegistered(
-            session.sessionDbId,
-            message.session_id
-          );
-          // Verify the update by reading back from DB
-          const verification = this.dbManager.getSessionStore().getSessionById(session.sessionDbId);
-          const dbVerified = verification?.memory_session_id === message.session_id;
-          const logMessage = previousId
-            ? `MEMORY_ID_CHANGED | sessionDbId=${session.sessionDbId} | from=${previousId} | to=${message.session_id} | dbVerified=${dbVerified}`
-            : `MEMORY_ID_CAPTURED | sessionDbId=${session.sessionDbId} | memorySessionId=${message.session_id} | dbVerified=${dbVerified}`;
-          logger.info('SESSION', logMessage, {
-            sessionId: session.sessionDbId,
-            memorySessionId: message.session_id,
-            previousId
-          });
-          if (!dbVerified) {
-            logger.error('SESSION', `MEMORY_ID_MISMATCH | sessionDbId=${session.sessionDbId} | expected=${message.session_id} | got=${verification?.memory_session_id}`, {
-              sessionId: session.sessionDbId
-            });
-          }
+          await this.registerCapturedMemorySessionId(session, message.session_id);
           // Debug-level alignment log for detailed tracing
           logger.debug('SDK', `[ALIGNMENT] ${previousId ? 'Updated' : 'Captured'} | contentSessionId=${session.contentSessionId} → memorySessionId=${message.session_id} | Future prompts will resume with this ID`);
         }
@@ -300,6 +278,45 @@ export class SDKAgent {
       sessionId: session.sessionDbId,
       duration: `${(sessionDuration / 1000).toFixed(1)}s`
     });
+  }
+
+  private async registerCapturedMemorySessionId(
+    session: ActiveSession,
+    memorySessionId: string
+  ): Promise<void> {
+    const previousId = session.memorySessionId;
+    session.memorySessionId = memorySessionId;
+    this.sessionManager.syncMemorySessionId(session.sessionDbId, memorySessionId);
+
+    const sessionStore = this.dbManager.getSessionStore();
+    sessionStore.ensureMemorySessionIdRegistered(session.sessionDbId, memorySessionId);
+
+    const verification = sessionStore.getSessionById(session.sessionDbId);
+    const dbVerified = verification?.memory_session_id === memorySessionId;
+    const logMessage = previousId
+      ? `MEMORY_ID_CHANGED | sessionDbId=${session.sessionDbId} | from=${previousId} | to=${memorySessionId} | dbVerified=${dbVerified}`
+      : `MEMORY_ID_CAPTURED | sessionDbId=${session.sessionDbId} | memorySessionId=${memorySessionId} | dbVerified=${dbVerified}`;
+
+    logger.info('SESSION', logMessage, {
+      sessionId: session.sessionDbId,
+      memorySessionId,
+      previousId
+    });
+
+    if (!dbVerified) {
+      logger.error('SESSION', `MEMORY_ID_MISMATCH | sessionDbId=${session.sessionDbId} | expected=${memorySessionId} | got=${verification?.memory_session_id}`, {
+        sessionId: session.sessionDbId
+      });
+    }
+
+    await backfillUnsyncedPrompts(
+      sessionStore,
+      session.contentSessionId,
+      memorySessionId,
+      session.project,
+      this.dbManager.getVectorSync(),
+      logger
+    );
   }
 
   /**

--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -320,7 +320,8 @@ export class SessionRoutes extends BaseRouteHandler {
 
     const session = this.sessionManager.initializeSession(sessionDbId, userPrompt, promptNumber);
 
-    // Get the latest user prompt for this session to sync to the active vector backend
+    // Get the latest user prompt for this session to broadcast to SSE clients.
+    // Vector sync is deferred until the provider has captured a real memory_session_id.
     const latestPrompt = this.dbManager.getSessionStore().getLatestUserPrompt(session.contentSessionId);
 
     // Broadcast new prompt to SSE clients (for web UI)
@@ -335,32 +336,6 @@ export class SessionRoutes extends BaseRouteHandler {
         created_at_epoch: latestPrompt.created_at_epoch
       });
 
-      // Sync user prompt to the selected vector backend
-      const vectorSyncStart = Date.now();
-      const promptText = latestPrompt.prompt_text;
-      this.dbManager.getVectorSync()?.syncUserPrompt(
-        latestPrompt.id,
-        latestPrompt.memory_session_id,
-        latestPrompt.project,
-        promptText,
-        latestPrompt.prompt_number,
-        latestPrompt.created_at_epoch
-      ).then(() => {
-        const vectorSyncDuration = Date.now() - vectorSyncStart;
-        const truncatedPrompt = promptText.length > 60
-          ? promptText.substring(0, 60) + '...'
-          : promptText;
-        logger.debug('CHROMA', 'User prompt synced', {
-          promptId: latestPrompt.id,
-          duration: `${vectorSyncDuration}ms`,
-          prompt: truncatedPrompt
-        });
-      }).catch((error) => {
-        logger.error('CHROMA', 'User prompt vector sync failed, continuing without vector search', {
-          promptId: latestPrompt.id,
-          prompt: promptText.length > 60 ? promptText.substring(0, 60) + '...' : promptText
-        }, error);
-      });
     }
 
     // Idempotent: ensure generator is running (matches handleObservations / handleSummarize)

--- a/src/services/worker/utils/promptBackfill.ts
+++ b/src/services/worker/utils/promptBackfill.ts
@@ -1,0 +1,53 @@
+import type { SessionStore } from '../../sqlite/SessionStore.js';
+import type { VectorSyncBackend } from '../../sync/VectorBackend.js';
+import { logger } from '../../../utils/logger.js';
+
+type PromptBackfillLogger = Pick<typeof logger, 'debug' | 'error'>;
+
+/**
+ * Backfill every prompt that was stored before a real memory session ID became available.
+ */
+export async function backfillUnsyncedPrompts(
+  sessionStore: SessionStore,
+  contentSessionId: string,
+  memorySessionId: string,
+  targetProject: string,
+  vectorSync: VectorSyncBackend | null,
+  log: PromptBackfillLogger
+): Promise<void> {
+  if (!vectorSync) {
+    return;
+  }
+
+  const prompts = sessionStore.getUnsyncedUserPromptsByContentSessionId(contentSessionId);
+  if (prompts.length === 0) {
+    return;
+  }
+
+  log.debug('CHROMA', 'Backfilling un-synced user prompts after memory session capture', {
+    contentSessionId,
+    memorySessionId,
+    promptCount: prompts.length,
+    backend: vectorSync.backend
+  });
+
+  for (const prompt of prompts) {
+    try {
+      await vectorSync.syncUserPrompt(
+        prompt.id,
+        memorySessionId,
+        targetProject,
+        prompt.prompt_text,
+        prompt.prompt_number,
+        prompt.created_at_epoch
+      );
+      sessionStore.markPromptVectorSynced(prompt.id, Date.now());
+    } catch (error) {
+      log.error('CHROMA', 'User prompt backfill failed, continuing with remaining prompts', {
+        promptId: prompt.id,
+        contentSessionId,
+        memorySessionId
+      }, error as Error);
+    }
+  }
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -113,6 +113,7 @@ export interface UserPromptRecord {
   content_session_id: string;
   prompt_number: number;
   prompt_text: string;
+  vector_synced_at?: number | null;
   project?: string;  // From JOIN with sdk_sessions
   memory_session_id?: string | null;
   platform_source?: string;
@@ -126,11 +127,12 @@ export interface UserPromptRecord {
 export interface LatestPromptResult {
   id: number;
   content_session_id: string;
-  memory_session_id: string;
+  memory_session_id: string | null;
   project: string;
   platform_source: string;
   prompt_number: number;
   prompt_text: string;
+  vector_synced_at: number | null;
   created_at_epoch: number;
 }
 

--- a/tests/services/sqlite/migration-runner.test.ts
+++ b/tests/services/sqlite/migration-runner.test.ts
@@ -116,6 +116,18 @@ describe('MigrationRunner', () => {
       expect(columnNames).toContain('content_hash');
     });
 
+    it('should create user_prompts with vector_synced_at column', () => {
+      const runner = new MigrationRunner(db);
+      runner.runAllMigrations();
+
+      const columns = getColumns(db, 'user_prompts');
+      const vectorSyncedColumn = columns.find(column => column.name === 'vector_synced_at');
+
+      expect(vectorSyncedColumn).toBeDefined();
+      expect(vectorSyncedColumn?.type).toBe('INTEGER');
+      expect(vectorSyncedColumn?.notnull).toBe(0);
+    });
+
     it('should record all migration versions', () => {
       const runner = new MigrationRunner(db);
       runner.runAllMigrations();
@@ -136,6 +148,7 @@ describe('MigrationRunner', () => {
       expect(versions).toContain(20);  // failed_at_epoch
       expect(versions).toContain(21);  // ON UPDATE CASCADE
       expect(versions).toContain(22);  // content_hash
+      expect(versions).toContain(29);  // user_prompts.vector_synced_at
     });
   });
 

--- a/tests/sqlite/prompts.test.ts
+++ b/tests/sqlite/prompts.test.ts
@@ -13,6 +13,8 @@ import { ClaudeMemDatabase } from '../../src/services/sqlite/Database.js';
 import {
   saveUserPrompt,
   getPromptNumberFromUserPrompts,
+  getUnsyncedUserPromptsByContentSessionId,
+  markPromptVectorSynced,
 } from '../../src/services/sqlite/Prompts.js';
 import { createSDKSession } from '../../src/services/sqlite/Sessions.js';
 import type { Database } from 'bun:sqlite';
@@ -124,6 +126,48 @@ describe('Prompts Module', () => {
       }
 
       expect(getPromptNumberFromUserPrompts(db, contentSessionId)).toBe(100);
+    });
+  });
+
+  describe('getUnsyncedUserPromptsByContentSessionId', () => {
+    it('should return un-synced prompts in id order, not latest-only', () => {
+      const contentSessionId = createSession('unsynced-prompts-session');
+      const prompt1Id = saveUserPrompt(db, contentSessionId, 1, 'First prompt');
+      const prompt2Id = saveUserPrompt(db, contentSessionId, 2, 'Second prompt');
+      const prompt3Id = saveUserPrompt(db, contentSessionId, 3, 'Third prompt');
+
+      markPromptVectorSynced(db, prompt2Id, Date.now());
+
+      const prompts = getUnsyncedUserPromptsByContentSessionId(db, contentSessionId);
+
+      expect(prompts.map(prompt => prompt.id)).toEqual([prompt1Id, prompt3Id]);
+      expect(prompts.map(prompt => prompt.prompt_number)).toEqual([1, 3]);
+      expect(prompts.every(prompt => prompt.vector_synced_at === null)).toBe(true);
+    });
+  });
+
+  describe('markPromptVectorSynced', () => {
+    it('should update vector_synced_at for the targeted prompt only', () => {
+      const contentSessionId = createSession('mark-prompt-synced-session');
+      const promptId = saveUserPrompt(db, contentSessionId, 1, 'Sync me');
+      const otherPromptId = saveUserPrompt(db, contentSessionId, 2, 'Leave me pending');
+      const syncedAt = Date.now();
+
+      markPromptVectorSynced(db, promptId, syncedAt);
+
+      const syncedPrompt = db.prepare(`
+        SELECT vector_synced_at
+        FROM user_prompts
+        WHERE id = ?
+      `).get(promptId) as { vector_synced_at: number | null };
+      const pendingPrompt = db.prepare(`
+        SELECT vector_synced_at
+        FROM user_prompts
+        WHERE id = ?
+      `).get(otherPromptId) as { vector_synced_at: number | null };
+
+      expect(syncedPrompt.vector_synced_at).toBe(syncedAt);
+      expect(pendingPrompt.vector_synced_at).toBeNull();
     });
   });
 });

--- a/tests/worker/agent-prompt-backfill.test.ts
+++ b/tests/worker/agent-prompt-backfill.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import { SDKAgent } from '../../src/services/worker/SDKAgent';
+import { GeminiAgent } from '../../src/services/worker/GeminiAgent';
+import { OpenRouterAgent } from '../../src/services/worker/OpenRouterAgent';
+import { logger } from '../../src/utils/logger.js';
+
+describe('agent prompt backfill', () => {
+  let loggerSpies: ReturnType<typeof spyOn>[];
+
+  beforeEach(() => {
+    loggerSpies = [
+      spyOn(logger, 'debug').mockImplementation(() => {}),
+      spyOn(logger, 'info').mockImplementation(() => {}),
+      spyOn(logger, 'warn').mockImplementation(() => {}),
+      spyOn(logger, 'error').mockImplementation(() => {}),
+    ];
+  });
+
+  afterEach(() => {
+    loggerSpies.forEach(spy => spy.mockRestore());
+    mock.restore();
+  });
+
+  function createSessionStoreMock(prompts: Array<{ id: number; prompt_number: number; prompt_text: string; created_at_epoch: number }>) {
+    return {
+      updateMemorySessionId: mock(() => {}),
+      ensureMemorySessionIdRegistered: mock(() => {}),
+      getSessionById: mock(() => ({ memory_session_id: 'captured-memory-session' })),
+      getUnsyncedUserPromptsByContentSessionId: mock(() => prompts.map(prompt => ({
+        ...prompt,
+        content_session_id: 'content-session-1',
+        created_at: new Date(prompt.created_at_epoch).toISOString(),
+        vector_synced_at: null
+      }))),
+      markPromptVectorSynced: mock(() => {})
+    };
+  }
+
+  function createVectorSyncMock() {
+    return {
+      backend: 'sqlite-vec' as const,
+      syncUserPrompt: mock(async () => {})
+    };
+  }
+
+  it('SDKAgent backfills every un-synced prompt after memory session capture', async () => {
+    const prompt1 = { id: 11, prompt_number: 1, prompt_text: 'First prompt', created_at_epoch: Date.now() - 10 };
+    const prompt2 = { id: 12, prompt_number: 2, prompt_text: 'Second prompt before first response', created_at_epoch: Date.now() - 5 };
+    const sessionStore = createSessionStoreMock([prompt1, prompt2]);
+    const vectorSync = createVectorSyncMock();
+    const sessionManager = {
+      syncMemorySessionId: mock(() => {})
+    } as any;
+    const dbManager = {
+      getSessionStore: () => sessionStore,
+      getVectorSync: () => vectorSync
+    } as any;
+    const agent = new SDKAgent(dbManager, sessionManager);
+    const session = {
+      sessionDbId: 1,
+      contentSessionId: 'content-session-1',
+      memorySessionId: null,
+      project: 'test-project'
+    } as any;
+
+    await (agent as any).registerCapturedMemorySessionId(session, 'captured-memory-session');
+
+    expect(sessionManager.syncMemorySessionId).toHaveBeenCalledWith(1, 'captured-memory-session');
+    expect(sessionStore.ensureMemorySessionIdRegistered).toHaveBeenCalledWith(1, 'captured-memory-session');
+    expect(vectorSync.syncUserPrompt).toHaveBeenNthCalledWith(
+      1,
+      prompt1.id,
+      'captured-memory-session',
+      'test-project',
+      prompt1.prompt_text,
+      prompt1.prompt_number,
+      prompt1.created_at_epoch
+    );
+    expect(vectorSync.syncUserPrompt).toHaveBeenNthCalledWith(
+      2,
+      prompt2.id,
+      'captured-memory-session',
+      'test-project',
+      prompt2.prompt_text,
+      prompt2.prompt_number,
+      prompt2.created_at_epoch
+    );
+    expect(sessionStore.markPromptVectorSynced).toHaveBeenCalledTimes(2);
+  });
+
+  it('GeminiAgent backfills prompts after generating its synthetic memory session id', async () => {
+    const prompt = { id: 21, prompt_number: 1, prompt_text: 'Gemini prompt', created_at_epoch: Date.now() };
+    const sessionStore = createSessionStoreMock([prompt]);
+    const vectorSync = createVectorSyncMock();
+    const dbManager = {
+      getSessionStore: () => sessionStore,
+      getVectorSync: () => vectorSync
+    } as any;
+    const agent = new GeminiAgent(dbManager, {} as any);
+    const session = {
+      contentSessionId: 'content-session-1',
+      project: 'test-project'
+    } as any;
+
+    await (agent as any).backfillPromptsAfterMemoryCapture(session, 'gemini-content-session-1-123');
+
+    expect(sessionStore.getUnsyncedUserPromptsByContentSessionId).toHaveBeenCalledWith('content-session-1');
+    expect(vectorSync.syncUserPrompt).toHaveBeenCalledWith(
+      prompt.id,
+      'gemini-content-session-1-123',
+      'test-project',
+      prompt.prompt_text,
+      prompt.prompt_number,
+      prompt.created_at_epoch
+    );
+    expect(sessionStore.markPromptVectorSynced).toHaveBeenCalledTimes(1);
+  });
+
+  it('OpenRouterAgent backfills prompts after generating its synthetic memory session id', async () => {
+    const prompt = { id: 31, prompt_number: 1, prompt_text: 'OpenRouter prompt', created_at_epoch: Date.now() };
+    const sessionStore = createSessionStoreMock([prompt]);
+    const vectorSync = createVectorSyncMock();
+    const dbManager = {
+      getSessionStore: () => sessionStore,
+      getVectorSync: () => vectorSync
+    } as any;
+    const agent = new OpenRouterAgent(dbManager, {} as any);
+    const session = {
+      contentSessionId: 'content-session-1',
+      project: 'test-project'
+    } as any;
+
+    await (agent as any).backfillPromptsAfterMemoryCapture(session, 'openrouter-content-session-1-123');
+
+    expect(sessionStore.getUnsyncedUserPromptsByContentSessionId).toHaveBeenCalledWith('content-session-1');
+    expect(vectorSync.syncUserPrompt).toHaveBeenCalledWith(
+      prompt.id,
+      'openrouter-content-session-1-123',
+      'test-project',
+      prompt.prompt_text,
+      prompt.prompt_number,
+      prompt.created_at_epoch
+    );
+    expect(sessionStore.markPromptVectorSynced).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/worker/prompt-backfill.test.ts
+++ b/tests/worker/prompt-backfill.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import { SessionStore } from '../../src/services/sqlite/SessionStore.js';
+import { backfillUnsyncedPrompts } from '../../src/services/worker/utils/promptBackfill.js';
+import { logger } from '../../src/utils/logger.js';
+
+describe('promptBackfill', () => {
+  let store: SessionStore;
+  let loggerSpies: ReturnType<typeof spyOn>[];
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:');
+    loggerSpies = [
+      spyOn(logger, 'debug').mockImplementation(() => {}),
+      spyOn(logger, 'error').mockImplementation(() => {})
+    ];
+  });
+
+  afterEach(() => {
+    store.close();
+    loggerSpies.forEach(spy => spy.mockRestore());
+    mock.restore();
+  });
+
+  function createSession(contentSessionId: string, project: string = 'test-project'): void {
+    store.createSDKSession(contentSessionId, project, 'initial prompt');
+  }
+
+  it('is a no-op when vector sync is disabled', async () => {
+    createSession('no-vector-sync');
+    const promptId = store.saveUserPrompt('no-vector-sync', 1, 'No backend available');
+
+    await backfillUnsyncedPrompts(
+      store,
+      'no-vector-sync',
+      'memory-session-1',
+      'test-project',
+      null,
+      logger
+    );
+
+    const prompt = store.db.prepare('SELECT vector_synced_at FROM user_prompts WHERE id = ?').get(promptId) as {
+      vector_synced_at: number | null;
+    };
+    expect(prompt.vector_synced_at).toBeNull();
+  });
+
+  it('syncs all un-synced prompts and marks them in id order', async () => {
+    createSession('sync-all-prompts');
+    const prompt1Id = store.saveUserPrompt('sync-all-prompts', 1, 'First prompt');
+    const prompt2Id = store.saveUserPrompt('sync-all-prompts', 2, 'Second prompt');
+
+    const syncCalls: number[] = [];
+    const vectorSync = {
+      backend: 'sqlite-vec',
+      syncUserPrompt: mock(async (promptId: number) => {
+        syncCalls.push(promptId);
+      })
+    } as any;
+
+    await backfillUnsyncedPrompts(
+      store,
+      'sync-all-prompts',
+      'memory-session-2',
+      'test-project',
+      vectorSync,
+      logger
+    );
+
+    const rows = store.db.prepare(`
+      SELECT id, vector_synced_at
+      FROM user_prompts
+      WHERE content_session_id = ?
+      ORDER BY id ASC
+    `).all('sync-all-prompts') as Array<{ id: number; vector_synced_at: number | null }>;
+
+    expect(syncCalls).toEqual([prompt1Id, prompt2Id]);
+    expect(rows).toEqual([
+      expect.objectContaining({ id: prompt1Id, vector_synced_at: expect.any(Number) }),
+      expect.objectContaining({ id: prompt2Id, vector_synced_at: expect.any(Number) }),
+    ]);
+  });
+
+  it('continues after a per-prompt sync failure', async () => {
+    createSession('sync-error-continue');
+    const prompt1Id = store.saveUserPrompt('sync-error-continue', 1, 'Fails first');
+    const prompt2Id = store.saveUserPrompt('sync-error-continue', 2, 'Succeeds second');
+
+    const vectorSync = {
+      backend: 'sqlite-vec',
+      syncUserPrompt: mock(async (promptId: number) => {
+        if (promptId === prompt1Id) {
+          throw new Error('boom');
+        }
+      })
+    } as any;
+
+    await backfillUnsyncedPrompts(
+      store,
+      'sync-error-continue',
+      'memory-session-3',
+      'test-project',
+      vectorSync,
+      logger
+    );
+
+    const rows = store.db.prepare(`
+      SELECT id, vector_synced_at
+      FROM user_prompts
+      WHERE content_session_id = ?
+      ORDER BY id ASC
+    `).all('sync-error-continue') as Array<{ id: number; vector_synced_at: number | null }>;
+
+    expect(rows).toEqual([
+      { id: prompt1Id, vector_synced_at: null },
+      expect.objectContaining({ id: prompt2Id, vector_synced_at: expect.any(Number) })
+    ]);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/worker/session-routes-vector-sync.test.ts
+++ b/tests/worker/session-routes-vector-sync.test.ts
@@ -54,7 +54,7 @@ describe('SessionRoutes vector sync routing', () => {
     rmSync(tempRoot, { recursive: true, force: true });
   });
 
-  it('syncs the latest user prompt through the active vector backend', async () => {
+  it('does not sync user prompts during session init before memory session capture', async () => {
     const dbPath = join(tempRoot, 'claude-mem.db');
     const dbManager = new DatabaseManager(dbPath);
     await dbManager.initialize();
@@ -74,13 +74,7 @@ describe('SessionRoutes vector sync routing', () => {
     const vectorSync = dbManager.getVectorSync();
     expect(vectorSync?.backend).toBe('sqlite-vec');
 
-    const pendingSyncs: Promise<void>[] = [];
-    const originalSyncUserPrompt = vectorSync!.syncUserPrompt.bind(vectorSync);
-    spyOn(vectorSync!, 'syncUserPrompt').mockImplementation((...args) => {
-      const promise = originalSyncUserPrompt(...args);
-      pendingSyncs.push(promise);
-      return promise;
-    });
+    const syncSpy = spyOn(vectorSync!, 'syncUserPrompt').mockResolvedValue(undefined);
 
     const routes = new SessionRoutes(
       sessionManager,
@@ -109,15 +103,15 @@ describe('SessionRoutes vector sync routing', () => {
     } as any;
 
     (routes as any).handleSessionInit(req, res);
-    await Promise.all(pendingSyncs);
 
-    const promptChunks = store.db.prepare(`
-      SELECT COUNT(*) AS count
-      FROM claude_mem_vec_chunks
-      WHERE sqlite_id = ? AND doc_type = 'user_prompt' AND project = ?
-    `).get(promptId, 'test-project') as { count: number };
+    const promptSyncState = store.db.prepare(`
+      SELECT vector_synced_at
+      FROM user_prompts
+      WHERE id = ?
+    `).get(promptId) as { vector_synced_at: number | null };
 
-    expect(promptChunks.count).toBeGreaterThan(0);
+    expect(syncSpy).not.toHaveBeenCalled();
+    expect(promptSyncState.vector_synced_at).toBeNull();
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
       status: 'initialized',
       sessionDbId,


### PR DESCRIPTION
Closes #37.

## Summary

Fixes the first-user-prompt vector indexing race + 3-agent coverage gap (issue #37).

- Adds `vector_synced_at` column to `user_prompts` (migration 029) so backfill knows what's pending.
- Removes route-level prompt sync from `SessionRoutes.ts` — the race condition disappears because nothing tries to sync before `memory_session_id` capture.
- Introduces shared `src/services/worker/utils/promptBackfill.ts` helper that all three agent paths (`SDKAgent`, `GeminiAgent`, `OpenRouterAgent`) call after `memory_session_id` is captured.
- `GeminiAgent` and `OpenRouterAgent` first prompts are now indexed for the first time (previously: completely missing).
- Multi-prompt-before-response is correctly handled: backfill loops over all un-synced prompts ordered by `id ASC`, not "latest only".
- Per-prompt error in backfill loop logs and continues so one bad prompt doesn't block the rest.

## Test plan

- [x] `bun test --preload ./tests/test-setup.ts` — **1403 pass / 3 skip / 0 fail**
- [x] New tests cover: migration column add, `getUnsyncedUserPromptsByContentSessionId`, `markPromptVectorSynced`, backfill helper (no-op + happy path + per-prompt error), all 3 agent paths, SessionRoutes no-sync behavior.
- [x] Pre-commit cumulative review by gemini-cli (model `gemini-3.1-pro-preview/xhigh`, session `01KP6X8G4MWJH3BD7KC4W1YK7P`): **decision=pass, 0 findings**.
- [x] Lefthook pre-commit hook (typecheck + tests) green.

## Implementation by

- Implementation: csa-codex (session `01KP6W80W3T3JGW91MPJ2646ZX`, ~15 min)
- Review: csa-gemini-cli (session `01KP6X8G4MWJH3BD7KC4W1YK7P`, ~1.5 min)
- Commit: csa-codex (session `01KP6XFBMQNHEGXA4CEWX4AZH0`, ~2.5 min)